### PR TITLE
fixed pickle bug

### DIFF
--- a/covid/commute.py
+++ b/covid/commute.py
@@ -118,6 +118,9 @@ class ModeOfTransport:
     def __repr__(self):
         return f"<{self.__class__.__name__} {self}>"
 
+    def __getnewargs__(self):
+        return self.description, self.is_public
+
     @classmethod
     def load_from_file(
             cls,


### PR DESCRIPTION
I have added a __getnewargs__ method to the ModeOfTransport class. Apparently having __new__ without this last method makes pickle not able to load the pickled object.