### PR TITLE
Slightly reworked AreaDistributor. 35 times faster on zone: NorthEast…

### DIFF
--- a/covid/groups/areas/area_distributor.py
+++ b/covid/groups/areas/area_distributor.py
@@ -7,7 +7,42 @@ class AreaDistributor:
     def __init__(self, areas, input_data):
         self.input = input_data
         self.areas = areas
-        self.area_mapping_df = self.areas.world.inputs.area_mapping_df
+        mapping_df = self.areas.world.inputs.area_mapping_df
+        # Reduce to the OA that are required --- reduces the search space later
+        self.area_mapping_df = mapping_df[mapping_df["OA"].isin(self.input.n_residents.index)]
+
+    def get_area_coord(self, area_name):
+        """
+        Read two numbers from input df, return as array.
+        """
+        import numpy as np
+        df_entry = self.input.areas_coordinates_df.loc[area_name]
+        # NOTE df["X"] ~5 times faster than df[ ["Y", "X"] ]
+        # FIXME explicit conversion to np.array necessary?
+        return np.array([df_entry["Y"], df_entry["X"]])
+
+    def areaname_to_msoa(self, area_name):
+        """
+        Find and return MSOA that corresponds to area_name.
+        """
+        # NOTE df["OA"] == area_name ~factor 2 slower than df["OA"].isin([area_name])
+        return self.area_mapping_df[ self.area_mapping_df["OA"].isin([area_name])  ]["MSOA"].unique()[0]
+
+    def mk_area(self, area_name):
+        area = Area(
+            self.areas.world,
+            area_name,
+            self.areaname_to_msoa(area_name),
+            self.input.n_residents.loc[area_name],
+            0,  # n_households_df.loc[area_name],
+            {
+                "age_freq": self.input.age_freq.loc[area_name],
+                "sex_freq": self.input.sex_freq.loc[area_name],
+                "household_freq": self.input.household_composition_freq.loc[area_name],
+            },
+            self.get_area_coord(area_name),
+        )
+        return area
 
     def read_areas_census(self):
         """
@@ -16,31 +51,14 @@ class AreaDistributor:
         It also initializes all the areas of the world.
         This is all on the OA layer.
         """
-        n_residents_df = self.input.n_residents
-        age_df = self.input.age_freq
-        sex_df = self.input.sex_freq
-        household_composition_df = self.input.household_composition_freq
         areas_list = []
-        oa_in_sim = n_residents_df.index
+        oa_in_sim = self.input.n_residents.index
+        import time
+        t0 = time.time()
+        ## This could be done in parallel
         for i, area_name in enumerate(oa_in_sim):
-            area_coord = self.input.areas_coordinates_df.loc[area_name][
-                ["Y", "X"]
-            ].values
-            area = Area(
-                self.areas.world,
-                area_name,
-                self.area_mapping_df[
-                    self.area_mapping_df["OA"] == area_name
-                ]["MSOA"].unique()[0],
-                n_residents_df.loc[area_name],
-                0,  # n_households_df.loc[area_name],
-                {
-                    "age_freq": age_df.loc[area_name],
-                    "sex_freq": sex_df.loc[area_name],
-                    "household_freq": household_composition_df.loc[area_name],
-                },
-                area_coord,
-            )
-            areas_list.append(area)
+            if (i+1)%100 == 0:
+                print("{}/{} freq: {} Hz".format(i+1, len(oa_in_sim), (i+1)/(time.time()-t0)), end="\r")
+            areas_list.append(self.mk_area(area_name))
         self.areas.members = areas_list
         self.areas.names_in_order = oa_in_sim


### PR DESCRIPTION
… due to reduced search space and use of what appears to be faster ways to access data in pandas

Hi,
the logic that maps an area_name to an MSOA is quite expensive in the NorthEast dataset
and could be accelerated.
`self.area_mapping_df[ self.area_mapping_df["OA"] == area_name  ]["MSOA"].unique()[0]`
It seems to be twice as fast to use df["OA"].isin([area_name]).
More importantly, the lookup is done on the whole input df which is 2.5M entries long.
By replacing
`self.area_mapping_df = self.areas.world.inputs.area_mapping_df `
with 
`mapping_df = self.areas.world.inputs.area_mapping_df
self.area_mapping_df = mapping_df[mapping_df["OA"].isin(self.input.n_residents.index)]
`
the search space is reduced to a df with about 100k entries, i.e. a df that only contains 
the data corresponding to the areas that are being looped over. The speedup is quite dramatic.

There is another performance gain when looking up the coordinates of the areas.
The code read
`df[ ["Y", "X"] ]`
which is about 5 times slower than individual lookups of df["Y"] and df["X"]

I hope this PR is ok, still quite new to this.