### PR TITLE
Similar changes as in area_distributor to speed up computation

### DIFF
--- a/covid/groups/msoareas/msoarea_distributor.py
+++ b/covid/groups/msoareas/msoarea_distributor.py
@@ -8,7 +8,14 @@ class MSOAreaDistributor:
     def __init__(self, msoareas):
         self.world = msoareas.world
         self.msoareas = msoareas
-        self.area_mapping_df = self.msoareas.world.inputs.area_mapping_df
+        self.msoareas.names_in_order = np.unique(
+                np.array([
+                    area.msoarea for area in self.world.areas.members
+                    ])
+                )
+        mapping_df = self.msoareas.world.inputs.area_mapping_df
+        # Search space reduction as we know where to look
+        self.area_mapping_df = mapping_df[mapping_df["MSOA"].isin(self.msoareas.names_in_order)]
         self.create_msoareas()
 
     def create_msoareas(self):
@@ -18,18 +25,13 @@ class MSOAreaDistributor:
         It also initializes all the areas of the world.
         This is all on the MSOA layer.
         """
-        msoa_in_sim = np.unique(
-            np.array([
-                area.msoarea for area in self.world.areas.members
-            ])
-        )
         msoareas_list = []
-        for msoa_name in msoa_in_sim:
+        for msoa_name in self.msoareas.names_in_order:
             # centroid of msoa
             coordinates = ['xxx', 'xxx']
             # find postcode inside this msoarea
             pcd_in_msoa = self.area_mapping_df[
-                self.area_mapping_df["MSOA"] == msoa_name
+                self.area_mapping_df["MSOA"].isin([msoa_name])
             ]["PCD"].values
             # find oareas inside this msoarea
             oa_in_msoa = [
@@ -50,4 +52,3 @@ class MSOAreaDistributor:
             for area in oa_in_msoa:
                 area.msoarea = msoarea
         self.msoareas.members = msoareas_list
-        self.msoareas.names_in_order = msoa_in_sim


### PR DESCRIPTION
Hi,
I made similar changes as in dev_faster_areadistibutor.
I replaced 
`df["MSOA"] == msoa_name`
with the faster
`df["MSOA"].isin([msoa_name])`
More importantly, the search space for the postcode lookup `pcd_in_msoa =...`
is reduced by modifying
`self.area_mapping_df=self.msoareas.world.inputs.area_mapping_df`
to
`mapping_df = self.msoareas.world.inputs.area_mapping_df
self.area_mapping_df = mapping_df[mapping_df["MSOA"].isin(self.msoareas.names_in_order)]
`
I also moved the assignment `self.msoareas.names_in_order` to `__init__` and iterate over
it in `create_msoareas`

I see a speedup of a factor 40 or so when running on the NorthEast dataset making the
call to `create_msoareas` quite fast.

Thanks,
Holger