### PR TITLE
structural change from list to dict

### DIFF
--- a/covid/groups/people/health_index.py
+++ b/covid/groups/people/health_index.py
@@ -46,10 +46,10 @@ RKIdata = [
 
 class HealthIndex:
     def __init__(self, config=None):
-        if config==None or "health_datafiles" not in config:
+        if config is None or "health_datafiles" not in config:
             self.ICdata  = ICdata
             self.RKIdata = RKIdata
-        if config!=None:
+        if config is not None:
             self.ratio   = config["infection"]["asymptomatic_ratio"]
         else:
             self.ratio = 0.4


### PR DESCRIPTION
Hi,
the Healthindex class has a structure that can probably be
better and a bit more efficiently expressed as a dictionary.

I changed `self.index_list = []` to `self.index_dict = {}` and 
fill the structure accordingly in `make_dict`.

The function `get_index_for_age` had a lookup signature that
required a loop over its items, it is now simply accessing the
dictionary by key.

Thanks,
Holger