### PR TITLE
More efficient flattening with or w/o itertools.chain

### DIFF
--- a/june/activity/activity_manager.py
+++ b/june/activity/activity_manager.py
@@ -139,7 +139,7 @@ class ActivityManager:
         """
 
         groups = [self.activity_to_group_dict[activity] for activity in activities]
-        return list(chain(*groups))
+        return list(chain.from_iterable(groups))
 
     def move_to_active_subgroup(
         self, activities: List[str], person: Person

--- a/june/demography/geography.py
+++ b/june/demography/geography.py
@@ -156,7 +156,7 @@ class SuperArea:
 
     @property
     def people(self):
-        return list(chain(*[area.people for area in self.areas]))
+        return list(chain.from_iterable(area.people for area in self.areas))
 
 
 class SuperAreas:
@@ -208,7 +208,7 @@ class SuperAreas:
                 k=k,
                 sort_results=True,
             )
-            indcs = chain(*indcs)
+            indcs = chain.from_iterable(indcs)
             super_areas = [self[idx] for idx in indcs]
             distances = distances.flatten()
             return super_areas, distances * earth_radius
@@ -219,7 +219,7 @@ class SuperAreas:
                 k=k,
                 sort_results=True,
             )
-            indcs = chain(*indcs)
+            indcs = chain.from_iterable(indcs)
             super_areas = [self[idx] for idx in indcs]
             return super_areas
 

--- a/june/simulator.py
+++ b/june/simulator.py
@@ -126,7 +126,8 @@ class Simulator:
         weekend_activities = [
             activity for activity in time_config["step_activities"]["weekend"].values()
         ]
-        all_activities = set(chain(*(weekday_activities + weekend_activities)))
+        all_activities = set(
+            chain.from_iterable(weekday_activities + weekend_activities))
 
         cls.check_inputs(time_config)
 
@@ -405,7 +406,8 @@ class Simulator:
                             )
                         # assign blame of infections
                         tprob_norm = sum(int_group.transmission_probabilities)
-                        for infector_id in chain(*int_group.infector_ids):
+                        for infector_id in chain.from_iterable(
+                                int_group.infector_ids):
                             infector = self.world.people[infector_id - first_person_id]
                             assert infector.id == infector_id
                             infector.health_information.number_of_infected += (

--- a/june/simulator_box.py
+++ b/june/simulator_box.py
@@ -135,7 +135,8 @@ class SimulatorBox(Simulator):
                             )
                         # assign blame of infections
                         tprob_norm = sum(int_group.transmission_probabilities)
-                        for infector_id in chain(*int_group.infector_ids):
+                        for infector_id in chain.from_iterable(
+                                int_group.infector_ids):
                             infector = self.world.people[infector_id]
                             infector.health_information.number_of_infected += (
                                 n_infected

--- a/june/utils/parse_probabilities.py
+++ b/june/utils/parse_probabilities.py
@@ -18,7 +18,9 @@ def parse_age_probabilities(age_dict: dict):
             bins.append(int(age_range_split[1]))
         probabilities.append(age_dict[age_range])
     sorting_idx = np.argsort(bins[::2])
-    bins = list(chain(*[[bins[2 * idx], bins[2 * idx + 1]] for idx in sorting_idx]))
+    bins = list(chain.from_iterable(
+        [bins[2 * idx], bins[2 * idx + 1]] for idx in sorting_idx
+    ))
     probabilities = np.array(probabilities)[sorting_idx]
     probabilities_binned = []
     for prob in probabilities:


### PR DESCRIPTION
I've noticed the codebase makes a fair amount of use of `itertools.chain`, which is good because it is quite fast, but such usage can be improved, mostly as described below, and as implemented in this code change suggestion.

1. Not making redundant conversions to lists: in e.g. a `for` loop  statement e.g. ``for item in list(chain(*nested_iterable))`` or a list comprehension e.g. ``[<this> for <that> in list(chain(...))]``, the wrapping with ``list(...)`` is not required since chain returns an iterator which is accepted by those constructs. As well as being unnecessary, it is better without ``list()`` because then the elements are taken from the `chain` iterator on-the-fly, rather than the entire list having to be created in memory which could cause memory issues if these list become very large.
2. Using an alternative constructor for `chain`, namely [`chain.from_iterable`](https://docs.python.org/3/library/itertools.html#itertools.chain.from_iterable) which takes a similar amount of time but does require the input to be unpacked.
3. There is one case where a ``chain`` is used with a ``numpy.array`` (in the form ``np.array(list(chain(*distances)))``) where it takes much less time, and is easier to interpret, to use ``numpy.flatten`` to get the same result.

After making these commits, I have ran the scripts and they run as they should, plus I have run the test battery and it passes:

```
...
simulator/test_simulator.py ..........                                   [100%]

----------- coverage: platform linux, python 3.8.5-final-0 -----------
Coverage XML written to file coverage.xml


======================= 348 passed in 474.24s (0:07:54) ========================
```


*********************

### Some profiling (if helpful)

1. [Clearly faster as it avoids a whole call, to ``list()``.]

2. From generating a large list with one-level nesting of other lists, and comparing the two methods using the following script:
```python
from itertools import chain
import numpy as np

import time
import memory_profiler


large_list_of_iterables = [
    ['A', 'B', 'C', 'D'] * 100, ['E', 'F'] * 5, ['G']] * 500000


@profile
def orig(): 
    return chain(*large_list_of_iterables)


#@profile
def new(): 
    return chain.from_iterable(large_list_of_iterables)


t1 = time.time()
orig_chain = orig()
t2 = time.time()
print("Time taken for original is:", round(t2-t1, 6))

t3 = time.time()
new_chain = new()
t4 = time.time()
print("Time taken using `.from_iterable` is", round(t4-t3, 6))

print("Same result from each?", list(orig_chain) == list(new_chain))

if __name__ == '__main__':
   orig()
   #new()
```
I get the output:
```console
> python -m memory_profiler time-chains.py
Time taken for original is: 0.008271
Time taken using `.from_iterable` is 4e-06
Same result from each? True
Filename: time-chains.py

Line #    Mem usage    Increment   Line Contents
================================================
    12   60.168 MiB   42.230 MiB   @profile
    13                             def orig(): 
    14   60.168 MiB   11.344 MiB       return chain(*large_list_of_iterables)
```
and by swapping the commenting-out of `@profile` and the calls inside ``if __name__ == '__main__':``:
```console
$ python -m memory_profiler time-chains.py
Time taken for original is: 0.007882
Time taken using `.from_iterable` is 0.000461
Same result from each? True
Filename: time-chains.py

Line #    Mem usage    Increment   Line Contents
================================================
    17   60.070 MiB   53.488 MiB   @profile
    18                             def new(): 
    19   60.070 MiB    0.000 MiB       return chain.from_iterable(large_list_of_iterables)
```
Generally the `from_iterable` approach seems much quicker for large lists and/or sub-lists and it does not require any increment in memory usage until each item needs to be consumed, on demand.

3. Replacing with `flatten`, where I am testing on an actual output ``repr`` of a distance array I set to be printed from a run, as copied here for reproducibility:

```python
from itertools import chain
import numpy as np

import time

distances = np.array(
    [[0.08873012],
     [0.02036478],
     [0.06360315],
     [0.04021098],
     [0.05320998],
     [0.02324569],
     [0.00029698],
     [0.03441185],
     [0.032607  ],
     [0.0001858 ],
     [0.10450698],
     [0.05973814],
     [0.00819391],
     [0.01326655],
     [0.05955742],
     [0.01425196],
     [0.00844153],
     [0.0079566 ],
     [0.01549402],
     [0.03636303],
     [0.01067303],
     [0.0262345 ],
     [0.09391553],
     [0.04701324],
     [0.11466506],
     [0.0469079 ],
     [0.09458642],
     [0.05396869],
     [0.09951041],
     [0.04219266],
     [0.00030747],
     [0.00617918],
     [0.00113252],
     [0.05019272],
     [0.03081745],
     [0.00140615],
     [0.003105  ],
     [0.0396507 ],
     [0.00028858],
     [0.0120007 ],
     [0.11514029],
     [0.10376452],
     [0.00128564],
     [0.12611   ],
     [0.00136953],
     [0.00130967],
     [0.00158388],
     [0.00020162],
     [0.05658252],
     [0.0655568 ],
     [0.04434329],
     [0.0349493 ],
     [0.03551696],
     [0.00100611],
     [0.10508402],
     [0.02866516],
     [0.01942231],
     [0.04580328],
     [0.04666222],
     [0.10470976],
     [0.0701828 ],
     [0.02147956],
     [0.07198359],
     [0.02497278],
     [0.0431336 ],
     [0.09609756],
     [0.05394611],
     [0.09254267],
     [0.13066047],
     [0.02924388],
     [0.01861258],
     [0.02592351],
     [0.03535371],
     [0.10455772],
     [0.00047229],
     [0.0469204 ],
     [0.0328978 ],
     [0.00070986],
     [0.05074576],
     [0.00407985],
     [0.00025194],
     [0.00219306],
     [0.01347246],
     [0.02346969],
     [0.01118636],
     [0.04528125],
     [0.03061709],
     [0.00026153],
     [0.00886748],
     [0.02901039],
     [0.05698043],
     [0.0002429 ],
     [0.05831027],
     [0.00447261],
     [0.04022139],
     [0.06197345],
     [0.03076451],
     [0.10442526],
     [0.01432986],
     [0.0947096 ],
     [0.00074284],
     [0.0354745 ],
     [0.07640443],
     [0.06035679],
     [0.0399484 ],
     [0.09945653],
     [0.09342191],
     [0.00244851],
     [0.06297338],
     [0.00480377],
     [0.06727474],
     [0.0076291 ],
     [0.0011416 ],
     [0.01303491],
     [0.04559659],
     [0.04850194],
     [0.00030747],
     [0.00112786],
     [0.02575524],
     [0.04700333],
     [0.0351629 ],
     [0.056594  ],
     [0.10427466],
     [0.05007939],
     [0.10464271],
     [0.03091017],
     [0.11458532],
     [0.06567072],
     [0.07603493],
     [0.07131991],
     [0.01728609],
     [0.03920896],
     [0.05584568],
     [0.00057992],
     [0.00043807],
     [0.00370894],
     [0.01587151],
     [0.00018267],
     [0.00020162],
     [0.05966991],
     [0.00127757],
     [0.00125768],
     [0.04572451],
     [0.07370217],
     [0.00048569],
     [0.04881857],
     [0.00060103],
     [0.01797284],
     [0.10644504],
     [0.05960921],
     [0.03834834],
     [0.03262273],
     [0.00324334],
     [0.01967461],
     [0.00020878],
     [0.05013485],
     [0.05966728],
     [0.00114373],
     [0.05322736],
     [0.03887141]]
)


t1 = time.time()
orig_distances = np.array(list(chain(*distances)))
t2 = time.time()

t3 = time.time()
new_distances = distances.flatten()
t4 = time.time()

print("Time taken for original is:", round(t2-t1, 6))
print("Time taken using flatten is:", round(t4-t3, 6))
print("Same result from each?", np.array_equal(orig_distances, new_distances))

```
for a representative output that I see is:
```console
$ py time-flatten.py 
Time taken for original is: 0.000281
Time taken using flatten is: 6e-06
Same result from each? True
```
showing the flatten is OOM 10-100 faster with that input. But plausibly much faster in most/all cases.