### PR TITLE
Faster initialisation of empty lists & dictionaries

### DIFF
--- a/june/commute.py
+++ b/june/commute.py
@@ -12,7 +12,7 @@ default_commute_file = paths.data_path / "input/commute/commute_ew.csv"
 
 
 class ModeOfTransport:
-    __all = dict()
+    __all = {}
 
     def __new__(
             cls,
@@ -285,7 +285,7 @@ class CommuteGenerator:
         -------
         An object used to generate commutes
         """
-        regional_generators = dict()
+        regional_generators = {}
         with open(filename) as f:
             reader = csv.reader(f)
             headers = next(reader)
@@ -294,7 +294,7 @@ class CommuteGenerator:
                 config_filename
             )
             for row in reader:
-                weighted_modes = list()
+                weighted_modes = []
                 for mode in modes_of_transport:
                     weighted_modes.append((
                         int(row[

--- a/june/demography/demography.py
+++ b/june/demography/demography.py
@@ -89,7 +89,7 @@ class AgeSexGenerator:
             ethnicity_age_counts, _ = np.histogram(
                 ages, bins=list(map(int, ethnicity_age_bins)) + [100]
             )
-            ethnicities = list()
+            ethnicities = []
             for age_ind, age_count in enumerate(ethnicity_age_counts):
                 ethnicities.extend(
                     np.random.choice(
@@ -171,7 +171,7 @@ class Population:
         people
             A list of people generated to match census data for that area
         """
-        self.people = people or list()
+        self.people = people or []
 
     def __len__(self):
         return len(self.people)
@@ -235,7 +235,7 @@ class Demography:
         -------
         A population of people
         """
-        people = list()
+        people = []
         age_and_sex_generator = self.age_sex_generators[area_name]
         for _ in range(age_and_sex_generator.n_residents):
             if ethnicity:

--- a/june/demography/geography.py
+++ b/june/demography/geography.py
@@ -58,9 +58,9 @@ class Area:
         self.care_home = None
         self.coordinates = coordinates
         self.super_area = super_area
-        self.people = list()
-        self.schools = list()
-        self.households = list()
+        self.people = []
+        self.schools = []
+        self.households = []
 
     def add(self, person: Person):
         self.people.append(person)
@@ -145,10 +145,10 @@ class SuperArea:
         self.id = next(self._id)
         self.name = name
         self.coordinates = coordinates
-        self.areas = areas or list()
-        self.workers = list()
-        self.companies = list()
-        self.groceries = list()
+        self.areas = areas or []
+        self.workers = []
+        self.companies = []
+        self.groceries = []
 
     def add_worker(self, person: Person):
         self.workers.append(person)

--- a/june/distributors/household_distributor.py
+++ b/june/distributors/household_distributor.py
@@ -299,7 +299,7 @@ class HouseholdDistributor:
         n_communal_df = pd.read_csv(n_people_in_communal_filename, index_col=0).loc[
             area_names
         ]
-        households_total = list()
+        households_total = []
         counter = 0
         for area, (_, number_households), (_, n_students), (_, n_communal) in zip(
             areas,

--- a/june/groups/commute/commutehub_distributor.py
+++ b/june/groups/commute/commutehub_distributor.py
@@ -36,7 +36,7 @@ class CommuteHubDistributor:
 
     def from_file(self):
 
-        coordinates_dict = dict()
+        coordinates_dict = {}
         with open(default_msoa_oa_coordinates) as f:
             reader = csv.reader(f)
             headers = next(reader)

--- a/june/groups/leisure/cinema.py
+++ b/june/groups/leisure/cinema.py
@@ -57,7 +57,7 @@ class Cinemas(SocialVenues):
 
     @classmethod
     def from_coordinates(cls, coordinates: List[np.array], **kwargs):
-        social_venues = list()
+        social_venues = []
         for coord in coordinates:
             sv = Cinema()
             sv.coordinates = coord

--- a/june/groups/leisure/grocery.py
+++ b/june/groups/leisure/grocery.py
@@ -57,7 +57,7 @@ class Groceries(SocialVenues):
 
     @classmethod
     def from_coordinates(cls, coordinates: List[np.array], **kwargs):
-        social_venues = list()
+        social_venues = []
         for coord in coordinates:
             sv = Grocery()
             sv.coordinates = coord

--- a/june/groups/leisure/pub.py
+++ b/june/groups/leisure/pub.py
@@ -58,7 +58,7 @@ class Pubs(SocialVenues):
 
     @classmethod
     def from_coordinates(cls, coordinates: List[np.array], **kwargs):
-        social_venues = list()
+        social_venues = []
         for coord in coordinates:
             sv = Pub()
             sv.coordinates = coord

--- a/june/groups/leisure/social_venue.py
+++ b/june/groups/leisure/social_venue.py
@@ -49,7 +49,7 @@ class SocialVenues(Supergroup):
             )
             distances_close = np.where(distances < max_distance_to_area)
             coordinates = coordinates[distances_close]
-        social_venues = list()
+        social_venues = []
         for coord in coordinates:
             sv = SocialVenue()
             sv.coordinates = coord

--- a/june/groups/university.py
+++ b/june/groups/university.py
@@ -93,7 +93,7 @@ class Universities(Supergroup):
         coordinates = coordinates[distances_close]
         n_students = n_students[distances_close]
         ukprn_values = ukprn_values[distances_close]
-        universities = list()
+        universities = []
         for coord, n_stud, ukprn in zip(
             coordinates, n_students, ukprn_values
         ):

--- a/june/hdf5_savers/carehome_saver.py
+++ b/june/hdf5_savers/carehome_saver.py
@@ -82,7 +82,7 @@ def load_care_homes_from_hdf5(file_path: str, chunk_size=50000):
     """
     with h5py.File(file_path, "r", libver="latest", swmr=True) as f:
         carehomes = f["care_homes"]
-        carehomes_list = list()
+        carehomes_list = []
         n_carehomes = carehomes.attrs["n_care_homes"]
         n_chunks = int(np.ceil(n_carehomes / chunk_size))
         for chunk in range(n_chunks):

--- a/june/hdf5_savers/commute_saver.py
+++ b/june/hdf5_savers/commute_saver.py
@@ -86,7 +86,7 @@ def load_commute_cities_from_hdf5(file_path: str):
     """
     with h5py.File(file_path, "r", libver="latest", swmr=True) as f:
         commute_cities = f["commute_cities"]
-        commute_cities_list = list()
+        commute_cities_list = []
         n_commute_cities = commute_cities.attrs["n_commute_cities"]
         ids = commute_cities["id"]
         city_names = commute_cities["city_names"]
@@ -155,7 +155,7 @@ def load_commute_hubs_from_hdf5(file_path: str):
     """
     with h5py.File(file_path, "r", libver="latest", swmr=True) as f:
         commute_hubs = f["commute_hubs"]
-        commute_hubs_list = list()
+        commute_hubs_list = []
         n_commute_hubs = commute_hubs.attrs["n_commute_hubs"]
         ids = commute_hubs["id"]
         city_names = commute_hubs["city_names"]

--- a/june/hdf5_savers/company_saver.py
+++ b/june/hdf5_savers/company_saver.py
@@ -86,7 +86,7 @@ def load_companies_from_hdf5(file_path: str, chunk_size=50000):
     with h5py.File(file_path, "r", libver="latest", swmr=True) as f:
         print("loading companies from hdf5 ", end="")
         companies = f["companies"]
-        companies_list = list()
+        companies_list = []
         n_companies = companies.attrs["n_companies"]
         n_chunks = int(np.ceil(n_companies / chunk_size))
         for chunk in range(n_chunks):

--- a/june/hdf5_savers/geography_saver.py
+++ b/june/hdf5_savers/geography_saver.py
@@ -75,7 +75,7 @@ def load_geography_from_hdf5(file_path: str, chunk_size=50000):
     with h5py.File(file_path, "r", libver="latest", swmr=True) as f:
         geography = f["geography"]
         n_areas = geography.attrs["n_areas"]
-        area_list = list()
+        area_list = []
         n_super_areas = geography.attrs["n_super_areas"]
         # areas
         n_chunks = int(np.ceil(n_areas / chunk_size))
@@ -91,7 +91,7 @@ def load_geography_from_hdf5(file_path: str, chunk_size=50000):
                 area.id = ids[k]
                 area_list.append(area)
         # super areas
-        super_area_list = list()
+        super_area_list = []
         n_chunks = int(np.ceil(n_super_areas / chunk_size))
         for chunk in range(n_chunks):
             idx1 = chunk * chunk_size

--- a/june/hdf5_savers/hospital_saver.py
+++ b/june/hdf5_savers/hospital_saver.py
@@ -86,7 +86,7 @@ def load_hospitals_from_hdf5(file_path: str, chunk_size=50000):
     """
     with h5py.File(file_path, "r", libver="latest", swmr=True) as f:
         hospitals = f["hospitals"]
-        hospitals_list = list()
+        hospitals_list = []
         chunk_size = 50000
         n_hospitals = hospitals.attrs["n_hospitals"]
         n_chunks = int(np.ceil(n_hospitals / chunk_size))

--- a/june/hdf5_savers/household_saver.py
+++ b/june/hdf5_savers/household_saver.py
@@ -165,7 +165,7 @@ def load_households_from_hdf5(file_path: str, chunk_size=50000):
     print("loading households from hdf5 ", end="")
     with h5py.File(file_path, "r", libver="latest", swmr=True) as f:
         households = f["households"]
-        households_list = list()
+        households_list = []
         n_households = households.attrs["n_households"]
         n_chunks = int(np.ceil(n_households / chunk_size))
         for chunk in range(n_chunks):

--- a/june/hdf5_savers/leisure_saver.py
+++ b/june/hdf5_savers/leisure_saver.py
@@ -24,7 +24,7 @@ def save_pubs_to_hdf5(pubs: Pubs, file_path: str):
 def load_pubs_from_hdf5(file_path: str):
     with h5py.File(file_path, "r", libver="latest", swmr=True) as f:
         pubs = f["pubs"]
-        pubs_list = list()
+        pubs_list = []
         n_pubs = pubs.attrs["n_pubs"]
         ids = pubs["id"]
         coordinates = pubs["coordinates"]
@@ -55,7 +55,7 @@ def save_groceries_to_hdf5(groceries: Groceries, file_path: str):
 def load_groceries_from_hdf5(file_path: str):
     with h5py.File(file_path, "r", libver="latest", swmr=True) as f:
         groceries = f["groceries"]
-        groceries_list = list()
+        groceries_list = []
         n_groceries = groceries.attrs["n_groceries"]
         ids = groceries["id"]
         coordinates = groceries["coordinates"]
@@ -87,7 +87,7 @@ def save_cinemas_to_hdf5(cinemas: Cinemas, file_path: str):
 def load_cinemas_from_hdf5(file_path: str):
     with h5py.File(file_path, "r", libver="latest", swmr=True) as f:
         cinemas = f["cinemas"]
-        cinemas_list = list()
+        cinemas_list = []
         n_cinemas = cinemas.attrs["n_cinemas"]
         ids = cinemas["id"]
         coordinates = cinemas["coordinates"]

--- a/june/hdf5_savers/population_saver.py
+++ b/june/hdf5_savers/population_saver.py
@@ -221,7 +221,7 @@ def load_population_from_hdf5(file_path: str, chunk_size=100000):
     """
     print("loading population from hdf5 ", end="")
     with h5py.File(file_path, "r", libver="latest", swmr=True) as f:
-        people = list()
+        people = []
         population = f["population"]
         # read in chunks of 100k people
         n_people = population.attrs["n_people"]

--- a/june/hdf5_savers/school_saver.py
+++ b/june/hdf5_savers/school_saver.py
@@ -90,7 +90,7 @@ def load_schools_from_hdf5(file_path: str, chunk_size: int = 50000):
     """
     with h5py.File(file_path, "r", libver="latest", swmr=True) as f:
         schools = f["schools"]
-        schools_list = list()
+        schools_list = []
         n_schools = schools.attrs["n_schools"]
         n_chunks = int(np.ceil(n_schools / chunk_size))
         for chunk in range(n_chunks):

--- a/june/hdf5_savers/university_saver.py
+++ b/june/hdf5_savers/university_saver.py
@@ -60,7 +60,7 @@ def load_universities_from_hdf5(file_path: str, chunk_size: int = 50000):
     """
     with h5py.File(file_path, "r", libver="latest", swmr=True) as f:
         universities = f["universities"]
-        universities_list = list()
+        universities_list = []
         n_universities = universities.attrs["n_universities"]
         ids = universities["id"]
         n_students_max = universities["n_students_max"]

--- a/june/infection/symptoms.py
+++ b/june/infection/symptoms.py
@@ -7,7 +7,7 @@ from june.infection.trajectory_maker import TrajectoryMakers
 
 class Symptoms:
     def __init__(self, health_index=None):
-        self.health_index = list() if health_index is None else health_index
+        self.health_index = [] if health_index is None else health_index
         self.tag = SymptomTag.exposed
         self.max_severity = random.random()
         self.trajectory = None

--- a/june/infection/trajectory_maker.py
+++ b/june/infection/trajectory_maker.py
@@ -247,7 +247,7 @@ class TrajectoryMaker:
         describing what symptoms the person should display at a given
         time.
         """
-        trajectory = list()
+        trajectory = []
         cumulative = 0.
         for stage in self.stages:
             time = stage.completion_time()

--- a/june/infection_seed/observed_to_cases.py
+++ b/june/infection_seed/observed_to_cases.py
@@ -103,7 +103,7 @@ class Observed2Cases:
         return regions
 
     def get_population(self, super_areas, regions):
-        population = dict()
+        population = {}
         for region in regions:
             population[region] = self.get_population_for_region(super_areas, region)
         return population


### PR DESCRIPTION
Trivial set of identical changes from:
* ``empty_list = list()`` to ``empty_list = []``; &
* ``empty_dict = dict()`` to ``empty_dict = {}``

that, depending on how many classes are instantiated (& I suspect quite a large amount based on what I have seen from the code), could speed up the code up somewhat, since the latter initialisations are ~3-4x (`list`s) or 4-5x (`dict`s) faster:

```console
$ python -mtimeit  "empty_list=[]"
10000000 loops, best of 5: 25.2 nsec per loop
$ python -mtimeit  "empty_list=list()"
5000000 loops, best of 5: 90.3 nsec per loop
$ python -mtimeit  "empty_dict={}"
10000000 loops, best of 5: 25.5 nsec per loop
$ python -mtimeit  "empty_dict=dict()"
2000000 loops, best of 5: 119 nsec per loop
```

Note that after these changes I have run the test suite & it still passes:

```
...
simulator/test_saving_checkpoint.py .                                    [ 97%]
simulator/test_simulator.py ..........                                   [100%]

----------- coverage: platform linux, python 3.8.5-final-0 -----------
Coverage XML written to file coverage.xml


======================= 348 passed in 460.49s (0:07:40) ========================
```