### PR TITLE
dont lose info when no infections happen!

### DIFF
--- a/june/logger/read_logger.py
+++ b/june/logger/read_logger.py
@@ -578,7 +578,7 @@ class ReadLogger:
         ].apply(list)
         super_area_df = super_area_df.set_index(["super_area", super_area_df.index])
         super_area_df = super_area_df.merge(
-            location_by_area, left_index=True, right_index=True
+            location_by_area, left_index=True, right_index=True, how='left',
         )
         super_area_df.reset_index(inplace=True)
         return super_area_df.set_index("time_stamp")


### PR DESCRIPTION
quickly fixed the summary created per run, so that it merges on infections and not on locations