### PR TITLE
Update health_index.py

### DIFF
--- a/june/epidemiology/infection/health_index/health_index.py
+++ b/june/epidemiology/infection/health_index/health_index.py
@@ -188,8 +188,8 @@ class HealthIndexGenerator:
             p[population][sex][age][0] = asymptomatic_rate  # recovers as asymptomatic
             p[population][sex][age][1] = mild_rate  # recovers as mild
             p[population][sex][age][2] = severe_rate  # recovers as severe
-            p[population][sex][age][3] = (
-                hospital_rate - hospital_dead_rate
+            p[population][sex][age][3] = max(
+                hospital_rate - hospital_dead_rate, 0
             )  # recovers in the ward
             p[population][sex][age][4] = max(
                 icu_rate - icu_dead_rate, 0


### PR DESCRIPTION
**Title**: Negative value from the recovery rate in the ward

**What:** 
- making sure that the `recovery rate (in the ward)` is larger than zero (In practice, we make sure that that is the case in the input data, but it would be nice to have it as a check and even print a warning if it finds negative values). Details can be found [here](https://github.com/IDAS-Durham/JUNE/issues/449)

- this change will make the codes for calculating the recovery rate being consistent to the other variables (such as `the recovers in the icu`)
